### PR TITLE
Fix missing resources in datapackage.json

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -58,6 +58,7 @@
       "name": "graph",
       "title": "Monthly Consumer Price Inflation",
       "specType": "simple",
+      "resources": [ "cpiai" ],
       "spec": {
         "type": "column",
         "group": "Date",
@@ -70,6 +71,7 @@
       "name": "graph",
       "title": "Monthly Consumer Price Index",
       "specType": "simple",
+      "resources": [ "cpiai" ],
       "spec": {
         "type": "line",
         "group": "Date",


### PR DESCRIPTION
Missing resources field in the datapackage.json

### Error
![image](https://github.com/datasets/cpi-us/assets/67981832/208e7cfc-44ca-4150-9997-8ae9f97ca1ee)

### Fixed version
![image](https://github.com/datasets/cpi-us/assets/67981832/9062e3f7-2642-43c7-8d74-d9adee42e475)
