### PR TITLE
fix: add cpi-us workflow write permissions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,6 +11,9 @@ on:
       - main
   workflow_dispatch: 
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
+++ b/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
@@ -1,0 +1,10 @@
+# Update Script Maintenance Report
+
+Date: 2026-03-03
+
+- Executed updater locally: `python scripts/process.py`.
+- Verified script executes and merges latest available CPI rows.
+- Added workflow write permission in `.github/workflows/actions.yml` (`permissions: contents: write`) so scheduled updates can push commits reliably.
+
+Note:
+- Automated updates depend on `BLS_API_KEY` in repository secrets for full historical range requests.


### PR DESCRIPTION
## Summary
- added `permissions: contents: write` to the CPI workflow so scheduled updates can push commits
- validated updater execution with `python scripts/process.py`
- added root-level `UPDATE_SCRIPT_MAINTENANCE_REPORT.md`

## Notes
- full automated historical refresh depends on `BLS_API_KEY` secret availability