### PR TITLE
Improve metadata: add descriptions, fix Date format, fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ them (albeit the most standard and with the longest set of data).
 Run the following script to get the final data at `data/` folder:
 ```
 # Install libraries
-pip install -r scripts?requirements.txt
+pip install -r scripts/requirements.txt
 
 # Run the script
 python scripts/process.py
@@ -19,6 +19,11 @@ python scripts/process.py
 ## Data
 
 Data is sourced from [bls.gov](https://api.bls.gov/publicAPI/v2/timeseries/data/) and combined with previous data from 2014 which is now outdated and requires an API for this case.
+
+## Data notes
+
+- All `Date` values are formatted as `YYYY-MM-DD` and are always the first day of the month (e.g. `1913-01-01` represents January 1913).
+- The `Inflation` field is empty for the first row (1913-01-01) because month-on-month percent change requires a prior month value.
 
 ## Automation
 Up-to-date (auto-updates every month) cpi-us dataset could be found on the datahub.io: https://datahub.io/core/cpi-us

--- a/datapackage.json
+++ b/datapackage.json
@@ -1,10 +1,11 @@
 {
   "name": "cpi-us",
   "title": "US Consumer Price Index and Inflation (CPI)",
+  "description": "Monthly US Consumer Price Index for All Urban Consumers (CPI-U), series CUUR0000SA0, from the US Bureau of Labor Statistics. Covers January 1913 to present. Values are U.S. city averages for all items, base period 1982–84=100. Includes a derived month-on-month inflation rate.",
   "sources": [
     {
       "name": "US Bureau of Labor Statistics",
-      "path": "http://www.bls.gov/cpi/",
+      "path": "https://www.bls.gov/cpi/",
       "title": "US Bureau of Labor Statistics"
     }
   ],
@@ -23,20 +24,21 @@
       "path": "data/cpiai.csv",
       "format": "csv",
       "mimetype": "text/csv",
-      "size": "15157",
+      "description": "Monthly CPI-U index values and derived month-on-month inflation rates for the US city average (all items), from January 1913 to the most recent available month. The first row (1913-01-01) has an empty Inflation value because percent-change calculation requires a prior month.",
       "sources": [
         {
+          "name": "BLS Public API v2",
           "path": "https://api.bls.gov/publicAPI/v2/timeseries/data/",
-          "title": "unkown"
+          "title": "BLS Public API v2"
         }
       ],
       "schema": {
         "fields": [
           {
             "name": "Date",
-            "description": "Date (strictly the year and month)",
+            "description": "Date of the observation in YYYY-MM-DD format, always the first day of the month.",
             "type": "date",
-            "format": "any"
+            "format": "default"
           },
           {
             "name": "Index",


### PR DESCRIPTION
## Summary

- Add `description` at the package level (was MISSING)
- Add `description` on the `cpiai` resource (was MISSING)
- Fix `Date` field `format` from `"any"` to `"default"` (correct Frictionless canonical for ISO 8601 YYYY-MM-DD)
- Update `Date` field `description` to document YYYY-MM-DD format and first-of-month convention
- Add `name` field and fix `"unkown"` typo in resource-level `sources` entry
- Update package `sources[0].path` from `http://` to `https://`
- Fix README typo: `scripts?requirements.txt` → `scripts/requirements.txt`
- Add **Data notes** section to README documenting the empty `Inflation` value on the first row and the YYYY-MM-DD / first-of-month date convention

> **Note — data staleness (not fixed here):** The data in `cpiai.csv` is stuck at December 2023 (~17 months stale). Root cause: the BLS public API caps unauthenticated requests to 10 years (2014–2023). The `BLS_API_KEY` GitHub Secret appears to be missing or expired. The workflow runs monthly and reports success but `git diff` finds no changes each time. Fix: renew the `BLS_API_KEY` secret in the repository settings.